### PR TITLE
Prefetch - link to wrong example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The commit consists of the following files (regardless if they were added, modif
 
 The output can be controlled using a config file named `appfairy_config.js` which should be located in the root of the project. The config file may (or may not) include some of the following options:
 
-- **prefetch (boolean)** - Prefetch the styles and scripts which are necessary for the design to work. If not specified, the scripts and styles will be fetched during runtime. An example app with prefetching enabled can be found [here](https://github.com/DAB0mB/Appfairy/tree/master/examples/nofetch).
+- **prefetch (boolean)** - Prefetch the styles and scripts which are necessary for the design to work. If not specified, the scripts and styles will be fetched during runtime. An example app with prefetching enabled can be found [here](https://github.com/DAB0mB/Appfairy/tree/master/examples/prefetch).
 
 - **source (source)** - Can either be set to `webflow`, `sketch` and represents the studio name that generated the basic CSS and HTML assets. If not set there will be little to no difference in the transpilation process but it will however make the CSS encapsulation more accurate. Examples for Webflow and Sketch apps can be found [here](https://github.com/DAB0mB/Appfairy/tree/master/examples).
 


### PR DESCRIPTION
I think this was supposed to be a link to the `prefetch` example, but it's linked to the `nofetch` example?