### PR TITLE
Fixed incorrect promise resolving in script-writer

### DIFF
--- a/src/writers/script-writer.js
+++ b/src/writers/script-writer.js
@@ -157,11 +157,9 @@ class ScriptWriter extends Writer {
         if (active.type == 'src') {
           scriptEl.src = active.body
 
-          loading = new Promise((resolve, reject) => {
-            scriptEl.onload = resolve
-            scriptEl.onerror = reject
-
-            return next
+          loading = new Promise((resolve) => {
+            scriptEl.onload = () => resolve(next)
+            scriptEl.onerror = () => resolve(next)
           })
         }
         else {


### PR DESCRIPTION
This PR fixes the issue with scripts loader. I have observed that some scripts return `<script type="text/javascript">undefined</script>` instead of expected script value.

This happens because of incorrect promise resolution.
Currently resolving the promise results in returning script onLoad event instead of next variable.

The issue lies with the fact that the return value from the promise executor is ignored. The variable should be passed to the resolve function instead.